### PR TITLE
Improve asynchronous BLF writer buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This is a library to access Binary Log File (BLF) files from Vector Informatik.
 
+## Performance tuning
+
+High-throughput recording setups can adjust the asynchronous writer buffers to
+avoid blocking producers. Use `Vector::BLF::File::setObjectQueueBufferSize()`
+and `Vector::BLF::File::setUncompressedFileBufferSize()` (or the combined
+`setWriteBufferSizes()` helper) to increase the number of objects and the amount
+of uncompressed data that may be staged in memory before it is compressed and
+written to disk.
+
 # Build on Linux (e.g. Debian Testing)
 
 Building under Linux works as usual:

--- a/src/Vector/BLF/File.h
+++ b/src/Vector/BLF/File.h
@@ -285,6 +285,42 @@ class VECTOR_BLF_EXPORT File final {
     virtual void setDefaultLogContainerSize(uint32_t defaultLogContainerSize);
 
     /**
+     * Get current buffer size of the asynchronous object queue.
+     *
+     * @return maximum number of objects buffered between the API and the writer thread
+     */
+    uint32_t objectQueueBufferSize() const;
+
+    /**
+     * Configure the buffer size of the asynchronous object queue.
+     *
+     * @param[in] bufferSize maximum number of buffered objects
+     */
+    void setObjectQueueBufferSize(uint32_t bufferSize);
+
+    /**
+     * Get current buffer size of the uncompressed data staging area.
+     *
+     * @return maximum amount of uncompressed bytes buffered in memory
+     */
+    std::streamsize uncompressedFileBufferSize() const;
+
+    /**
+     * Configure the buffer size of the uncompressed data staging area.
+     *
+     * @param[in] bufferSize maximum amount of uncompressed bytes buffered in memory
+     */
+    void setUncompressedFileBufferSize(std::streamsize bufferSize);
+
+    /**
+     * Configure both write buffer sizes at once.
+     *
+     * @param[in] objectQueueSize maximum number of buffered objects
+     * @param[in] uncompressedBufferSize maximum amount of uncompressed bytes buffered in memory
+     */
+    void setWriteBufferSizes(uint32_t objectQueueSize, std::streamsize uncompressedBufferSize);
+
+    /**
      * create object of given type
      *
      * @param type object type
@@ -312,6 +348,11 @@ class VECTOR_BLF_EXPORT File final {
      */
     ObjectQueue<ObjectHeaderBase> m_readWriteQueue {};
 
+    /**
+     * Maximum number of objects buffered by m_readWriteQueue.
+     */
+    uint32_t m_objectQueueBufferSize {1024};
+
     /* uncompressed file */
 
     /**
@@ -322,6 +363,11 @@ class VECTOR_BLF_EXPORT File final {
      * The compressionThread transfers data from/to here into the uncompressedFile.
      */
     UncompressedFile m_uncompressedFile {};
+
+    /**
+     * Maximum number of uncompressed bytes kept in memory before they are compressed and written to disk.
+     */
+    std::streamsize m_uncompressedFileBufferSize {};
 
     /**
      * thread between readWriteQueue and uncompressedFile
@@ -405,6 +451,16 @@ class VECTOR_BLF_EXPORT File final {
      * transfer data from uncompressedfile to compressedFile
      */
     static void compressedFileWriteThread(File * file);
+
+    /**
+     * Apply the configured object queue buffer size to the queue instance.
+     */
+    void updateObjectQueueBufferSize();
+
+    /**
+     * Apply the configured uncompressed buffer size to the staging buffer instance.
+     */
+    void updateUncompressedFileBufferSize();
 };
 
 }

--- a/src/Vector/BLF/tests/unittests/test_File.cpp
+++ b/src/Vector/BLF/tests/unittests/test_File.cpp
@@ -62,6 +62,29 @@ BOOST_AUTO_TEST_CASE(defaultContainerSize) {
     BOOST_CHECK_EQUAL(file.defaultLogContainerSize(), 0x30000);
 }
 
+/** test getter/setter for buffer configuration */
+BOOST_AUTO_TEST_CASE(bufferConfiguration) {
+    Vector::BLF::File file;
+
+    const auto defaultContainerSize = file.defaultLogContainerSize();
+    BOOST_CHECK_EQUAL(file.objectQueueBufferSize(), 1024U);
+    BOOST_CHECK_EQUAL(
+        file.uncompressedFileBufferSize(),
+        static_cast<std::streamsize>(defaultContainerSize) * 4);
+
+    file.setWriteBufferSizes(2048U, static_cast<std::streamsize>(defaultContainerSize) * 8);
+    BOOST_CHECK_EQUAL(file.objectQueueBufferSize(), 2048U);
+    BOOST_CHECK_EQUAL(
+        file.uncompressedFileBufferSize(),
+        static_cast<std::streamsize>(defaultContainerSize) * 8);
+
+    file.setObjectQueueBufferSize(0U);
+    BOOST_CHECK_EQUAL(file.objectQueueBufferSize(), 1U);
+
+    file.setUncompressedFileBufferSize(1);
+    BOOST_CHECK_EQUAL(file.uncompressedFileBufferSize(), static_cast<std::streamsize>(file.defaultLogContainerSize()));
+}
+
 /** Test file with only two CanMessages, but no LogContainers. */
 BOOST_AUTO_TEST_CASE(fileWithoutLogContainers) {
     Vector::BLF::File file;


### PR DESCRIPTION
## Summary
- raise the default asynchronous queue buffers so background compression keeps up with high throughput writers
- add public APIs to tune queue and uncompressed buffer sizes and document their usage
- cover the new configuration helpers with unit tests

## Testing
- cmake -S . -B build -DOPTION_BUILD_TESTS=ON -DOPTION_RUN_DOXYGEN=OFF *(fails: missing Boost 1.55)*

------
https://chatgpt.com/codex/tasks/task_e_68d10fc19ee88325b74d53fc9bcb88f7